### PR TITLE
cuda: dropping some cuda deps for 0.19.0

### DIFF
--- a/pkgs/development/python-modules/amd-aiter/default.nix
+++ b/pkgs/development/python-modules/amd-aiter/default.nix
@@ -1,0 +1,134 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  setuptools,
+  setuptools-scm,
+  packaging,
+  psutil,
+  pybind11,
+  einops,
+  ninja,
+  numpy,
+  pandas,
+  rocmPackages,
+  torch,
+  writableTmpDirAsHomeHook,
+
+  gpuTargets ? rocmPackages.clr.localGpuTargets or rocmPackages.clr.gpuTargets,
+  # From validate_and_update_archs at https://github.com/ROCm/aiter/blob/main/aiter/jit/core.py
+  supportedGpuTargets ? [
+    "gfx90a"
+    "gfx940"
+    "gfx941"
+    "gfx942"
+    "gfx1100"
+    "gfx1101"
+    "gfx1102"
+    "gfx1103"
+    "gfx1150"
+    "gfx1151"
+    "gfx1152"
+    "gfx1153"
+    "gfx1200"
+    "gfx1201"
+    "gfx950"
+  ],
+}:
+buildPythonPackage (finalAttrs: {
+  pname = "amd-aiter";
+  version = "0.1.11.post1";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "ROCm";
+    repo = "aiter";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-9CCSmEw0kIoxERhtkKhBkaAGx42kCssH7IPjTgbg9LA=";
+  };
+
+  postPatch = ''
+    rmdir 3rdparty/composable_kernel
+    ln -sf ${rocmPackages.composable_kernel.src} 3rdparty/composable_kernel
+
+    # python relax deps hook?
+    substituteInPlace pyproject.toml \
+      --replace-fail '"flydsl==0.0.1.dev95158637"' ""
+
+    # TODO: upstream fix. get_git_commit_id_short() assumes a git clone;
+    # fails in hermetic builds, should fall back gracefully.
+    substituteInPlace csrc/cpp_itfs/utils.py \
+      --replace-fail \
+        'commit_id = get_git_commit_id_short()' \
+        'commit_id = "${finalAttrs.version}"'
+
+    # setuptools runs setup.py twice (metadata + wheel). prepare_packaging()
+    # copies 3rdparty/ (with nix store read-only files) into aiter_meta/, then
+    # the second run can't rmtree or overwrite them.
+    substituteInPlace setup.py \
+      --replace-fail \
+        $'prepare_packaging()\n\n\nclass' \
+        $'if not os.path.exists("aiter_meta"): prepare_packaging()\n\n\nclass' \
+      --replace-fail \
+        'if os.path.exists("aiter_meta") and os.path.isdir("aiter_meta"):' \
+        'if False:'
+  '';
+
+  env = {
+    SETUPTOOLS_SCM_PRETEND_VERSION = finalAttrs.version;
+    PREBUILD_KERNELS = "0";
+    BUILD_TARGET = "rocm";
+    ROCM_PATH = "${rocmPackages.clr}";
+    # FIXME does it even matter when PREBUILD_KERNELS is off?
+    GPU_ARCHS = lib.concatStringsSep ";" (lib.lists.intersectLists gpuTargets supportedGpuTargets);
+  };
+
+  build-system = [
+    setuptools
+    setuptools-scm
+    packaging
+    psutil
+    pybind11
+    ninja
+    pandas
+  ];
+
+  buildInputs = [ rocmPackages.clr ];
+
+  nativeBuildInputs = [
+    rocmPackages.hipcc
+    writableTmpDirAsHomeHook
+  ];
+
+  pythonImportsCheck = [ "aiter" ];
+
+  dependencies = [
+    einops
+    ninja
+    numpy
+    packaging
+    pandas
+    psutil
+    pybind11
+    torch
+  ];
+
+  # Import requires writable $HOME (JIT cache) and ROCm GPU
+  # pythonImportsCheck = [ "aiter" ];
+
+  # Most of the tests require gpu
+  doCheck = false;
+
+  meta = {
+    description = "AI Tensor Engine for ROCm";
+    homepage = "https://github.com/ROCm/aiter";
+    license = lib.licenses.mit;
+    sourceProvenance = with lib.sourceTypes; [
+      fromSource
+      binaryNativeCode
+    ];
+    maintainers = with lib.maintainers; [ lach ];
+    teams = [ lib.teams.rocm ];
+    platforms = lib.platforms.linux;
+  };
+})

--- a/pkgs/development/python-modules/kaldi-native-fbank/default.nix
+++ b/pkgs/development/python-modules/kaldi-native-fbank/default.nix
@@ -1,0 +1,46 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  cmake,
+  setuptools,
+  pybind11,
+  kissfft,
+}:
+buildPythonPackage (finalAttrs: {
+  pname = "kaldi-native-fbank";
+  version = "1.22.3";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "csukuangfj";
+    repo = "kaldi-native-fbank";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-Wu4wM52T6NoQ1t5/iAyPtkEGnZki5P0jx0eYMFZMb5o=";
+  };
+
+  build-system = [
+    cmake
+    setuptools
+  ];
+
+  buildInputs = [ pybind11 ];
+
+  dontUseCmakeConfigure = true;
+
+  env.KALDI_NATIVE_FBANK_CMAKE_ARGS = lib.concatStringsSep " " [
+    "-DFETCHCONTENT_SOURCE_DIR_KISSFFT=${kissfft.src}"
+    "-DFETCHCONTENT_SOURCE_DIR_PYBIND11=${pybind11.src}"
+    "-DKALDI_NATIVE_FBANK_BUILD_TESTS=OFF"
+    "-DKALDI_NATIVE_FBANK_BUILD_PYTHON=ON"
+  ];
+
+  pythonImportsCheck = [ "kaldi_native_fbank" ];
+
+  meta = {
+    description = "Kaldi-compatible online fbank extractor without external dependencies";
+    homepage = "https://github.com/csukuangfj/kaldi-native-fbank";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ lach ];
+  };
+})

--- a/pkgs/development/python-modules/opentelemetry-api/default.nix
+++ b/pkgs/development/python-modules/opentelemetry-api/default.nix
@@ -14,7 +14,7 @@
 let
   self = buildPythonPackage rec {
     pname = "opentelemetry-api";
-    version = "1.34.0";
+    version = "1.40.0";
     pyproject = true;
 
     # to avoid breakage, every package in opentelemetry-python must inherit this version, src, and meta
@@ -22,7 +22,7 @@ let
       owner = "open-telemetry";
       repo = "opentelemetry-python";
       tag = "v${version}";
-      hash = "sha256-fAXcS2VyDMk+UDW3ru5ZvwzXjydsY1uFcT2GvZuiGWw=";
+      hash = "sha256-1KVy9s+zjlB4w7E45PMCWRxPus24bgBmmM3k2R9d+Jg=";
     };
 
     sourceRoot = "${src.name}/opentelemetry-api";

--- a/pkgs/development/python-modules/opentelemetry-instrumentation/default.nix
+++ b/pkgs/development/python-modules/opentelemetry-instrumentation/default.nix
@@ -12,7 +12,7 @@
 
 buildPythonPackage rec {
   pname = "opentelemetry-instrumentation";
-  version = "0.55b0";
+  version = "0.61b0";
   pyproject = true;
 
   # To avoid breakage, every package in opentelemetry-python-contrib must inherit this version, src, and meta
@@ -20,7 +20,7 @@ buildPythonPackage rec {
     owner = "open-telemetry";
     repo = "opentelemetry-python-contrib";
     tag = "v${version}";
-    hash = "sha256-UM9ezCh3TVwyj257O0rvTCIgfrddobWcVIgJmBUj/Vo=";
+    hash = "sha256-DT13gcYPNYXBPnf622WsA16C+7sabJfOshDquHn06Ok=";
   };
 
   sourceRoot = "${src.name}/opentelemetry-instrumentation";

--- a/pkgs/development/python-modules/opentelemetry-semantic-conventions-ai/default.nix
+++ b/pkgs/development/python-modules/opentelemetry-semantic-conventions-ai/default.nix
@@ -1,0 +1,38 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchPypi,
+  hatchling,
+  opentelemetry-sdk,
+  opentelemetry-semantic-conventions,
+}:
+let
+  version = "0.4.15";
+in
+buildPythonPackage {
+  pname = "opentelemetry-semantic-conventions-ai";
+  inherit version;
+  pyproject = true;
+
+  src = fetchPypi {
+    pname = "opentelemetry_semantic_conventions_ai";
+    inherit version;
+    hash = "sha256-Et4XLR4R0hxugrv1eMfopxNYmn/adq+e14VjJWSii4E=";
+  };
+
+  build-system = [ hatchling ];
+
+  dependencies = [
+    opentelemetry-sdk
+    opentelemetry-semantic-conventions
+  ];
+
+  pythonImportsCheck = [ "opentelemetry.semconv_ai" ];
+
+  meta = {
+    description = "Open-source observability for your GenAI or LLM application, based on OpenTelemetry";
+    homepage = "https://github.com/traceloop/openllmetry";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ lach ];
+  };
+}

--- a/pkgs/development/python-modules/vllm/0006-drop-rocm-extra-reqs.patch
+++ b/pkgs/development/python-modules/vllm/0006-drop-rocm-extra-reqs.patch
@@ -2,19 +2,17 @@ diff --git a/requirements/rocm.txt b/requirements/rocm.txt
 index 375f0a019..04a59dc3b 100644
 --- a/requirements/rocm.txt
 +++ b/requirements/rocm.txt
-@@ -9,4 +9,2 @@ ray[cgraph]>=2.48.0 # Ray Compiled Graph, required for pipeline parallelism in V1.
+@@ -10,13 +10,7 @@
+ # Dependencies for AMD GPUs
+ datasets
  peft
 -pytest-asyncio
 -tensorizer==2.10.1
  packaging>=24.2
-@@ -12,6 +10,2 @@ tensorizer==2.10.1
- packaging>=24.2
 -setuptools>=77.0.3,<80.0.0
 -setuptools-scm>=8
--runai-model-streamer[s3,gcs]==0.15.3
+-runai-model-streamer[s3,gcs,azure]==0.15.7
 -conch-triton-kernels==1.2.1
  timm>=1.0.17
- grpcio-tools>=1.76.0
-@@ -17,2 +13,1 @@ conch-triton-kernels==1.2.1
- timm>=1.0.17
--grpcio-tools>=1.76.0
+ # amd-quark: required for Quark quantization on ROCm
+ # To be consistent with test_quark.py

--- a/pkgs/development/python-modules/vllm/0007-drop-quack-reqs.patch
+++ b/pkgs/development/python-modules/vllm/0007-drop-quack-reqs.patch
@@ -1,0 +1,12 @@
+diff --git a/requirements/cuda.txt b/requirements/cuda.txt
+index 22477dc82..84fe34730 100644
+--- a/requirements/cuda.txt
++++ b/requirements/cuda.txt
+@@ -14,7 +14,3 @@
+ # Cap nvidia-cudnn-frontend (transitive dep of flashinfer) due to
+ # breaking changes in 1.19.0
+ nvidia-cudnn-frontend>=1.13.0,<1.19.0
+-
+-# QuACK and Cutlass DSL for FA4 (cute-DSL implementation)
+-nvidia-cutlass-dsl>=4.4.0.dev1
+-quack-kernels>=0.2.7

--- a/pkgs/development/python-modules/vllm/0008-drop-flashinfer-cubin.patch
+++ b/pkgs/development/python-modules/vllm/0008-drop-flashinfer-cubin.patch
@@ -1,0 +1,15 @@
+diff --git a/requirements/cuda.txt b/requirements/cuda.txt
+index fe566db35..44b7c3809 100644
+--- a/requirements/cuda.txt
++++ b/requirements/cuda.txt
+@@ -10,7 +10,6 @@ torchaudio==2.10.0
+ torchvision==0.25.0 # Required for phi3v processor. See https://github.com/pytorch/vision?tab=readme-ov-file#installation for corresponding version
+ # FlashInfer should be updated together with the Dockerfile
+ flashinfer-python==0.6.6
+-flashinfer-cubin==0.6.6
+ # Cap nvidia-cudnn-frontend (transitive dep of flashinfer) due to
+ # breaking changes in 1.19.0
+ nvidia-cudnn-frontend>=1.13.0,<1.19.0
+--
+2.51.2
+

--- a/pkgs/development/python-modules/vllm/0009-drop-transitive-nvidia-cudnn-frontend.patch
+++ b/pkgs/development/python-modules/vllm/0009-drop-transitive-nvidia-cudnn-frontend.patch
@@ -1,0 +1,11 @@
+diff --git a/requirements/cuda.txt b/requirements/cuda.txt
+index a7676ef62..b44cbfabc 100644
+--- a/requirements/cuda.txt
++++ b/requirements/cuda.txt
+@@ -10,6 +10,3 @@ torchaudio==2.10.0
+ torchvision==0.25.0 # Required for phi3v processor. See https://github.com/pytorch/vision?tab=readme-ov-file#installation for corresponding version
+ # FlashInfer should be updated together with the Dockerfile
+ flashinfer-python==0.6.6
+-# Cap nvidia-cudnn-frontend (transitive dep of flashinfer) due to
+-# breaking changes in 1.19.0
+-nvidia-cudnn-frontend>=1.13.0,<1.19.0

--- a/pkgs/development/python-modules/vllm/default.nix
+++ b/pkgs/development/python-modules/vllm/default.nix
@@ -359,6 +359,12 @@ buildPythonPackage.override { stdenv = torch.stdenv; } (finalAttrs: {
     # QuACK and Cutlass DSL seem to be added only for FA4
     # which in our case handles its own deps
     ./0007-drop-quack-reqs.patch
+    # AOT/pre-compiled kernels, primarily targeting blackwell,
+    # should work ok with JIT
+    ./0008-drop-flashinfer-cubin.patch
+    # was just used to pin transitive dep version, which
+    # doesn't affect us at the moment
+    ./0009-drop-transitive-nvidia-cudnn-frontend.patch
   ];
 
   postPatch = ''

--- a/pkgs/development/python-modules/vllm/default.nix
+++ b/pkgs/development/python-modules/vllm/default.nix
@@ -93,6 +93,8 @@
   cupy,
   flashinfer,
   nvidia-ml-py,
+  # rocm-only
+  pybind11,
 
   # optional-dependencies
   # audio
@@ -584,11 +586,46 @@ buildPythonPackage.override { stdenv = torch.stdenv; } (finalAttrs: {
   pythonRelaxDeps = true;
 
   pythonImportsCheck = [ "vllm" ];
-  makeWrapperArgs = lib.optionals cudaSupport [
-    "--set"
-    "VLLM_NCCL_SO_PATH"
-    "${cudaPackages.nccl}/lib/libnccl.so"
-  ];
+  makeWrapperArgs =
+    lib.optionals cudaSupport [
+      "--set"
+      "VLLM_NCCL_SO_PATH"
+      "${cudaPackages.nccl}/lib/libnccl.so"
+    ]
+    ++ lib.optionals rocmSupport [
+      "--set"
+      "CPLUS_INCLUDE_PATH"
+      (lib.concatStringsSep ":" (
+        map (p: "${lib.getInclude p}/include") (
+          (with rocmPackages; [
+            rocthrust
+            rocprim
+            clr
+            hipsparse
+            hipblas
+            hipblas-common
+            hipblaslt
+            hipsolver
+            rocsparse
+            rocblas
+            rocsolver
+            hipfft
+          ])
+          ++ [
+            pybind11
+          ]
+        )
+      ))
+
+      "--set"
+      "HIP_DEVICE_LIB_PATH"
+      "${rocmPackages.rocm-device-libs}/amdgcn/bitcode"
+
+      "--prefix"
+      "PATH"
+      ":"
+      "${rocmPackages.clr}/bin"
+    ];
 
   passthru = {
     # make internal dependency available to overlays

--- a/pkgs/development/python-modules/vllm/default.nix
+++ b/pkgs/development/python-modules/vllm/default.nix
@@ -27,6 +27,8 @@
 
   # dependencies
   aioprometheus,
+  amd-aiter,
+  amd-quark,
   amdsmi,
   anthropic,
   bitsandbytes,
@@ -43,6 +45,7 @@
   grpcio-reflection,
   ijson,
   importlib-metadata,
+  kaldi-native-fbank,
   llguidance,
   lm-format-enforcer,
   mcp,
@@ -57,6 +60,7 @@
   opentelemetry-api,
   opentelemetry-exporter-otlp,
   opentelemetry-sdk,
+  opentelemetry-semantic-conventions-ai,
   outlines,
   pandas,
   partial-json-parser,
@@ -174,8 +178,8 @@ let
   triton-kernels = fetchFromGitHub {
     owner = "triton-lang";
     repo = "triton";
-    tag = "v3.5.0";
-    hash = "sha256-F6T0n37Lbs+B7UHNYzoIQHjNNv3TcMtoXjNrT8ZUlxY=";
+    tag = "v3.6.0";
+    hash = "sha256-JFSpQn+WsNnh7CAPlcpOcUp0nyKXNbJEANdXqmkt4Tc=";
   };
 
   # grep for GIT_TAG in the following file
@@ -335,14 +339,14 @@ in
 
 buildPythonPackage.override { stdenv = torch.stdenv; } (finalAttrs: {
   pname = "vllm";
-  version = "0.16.0";
+  version = "0.19.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "vllm-project";
     repo = "vllm";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-7E67xVRlKmm+Hbp5nphhwH8SQC9LpCFNBfF2ZAOt79k=";
+    hash = "sha256-0gM52DDfLzkE4QXCGR3c3Jq4CQ1PrnDj4Ky0lsUJ2a8=";
   };
 
   patches = [
@@ -350,6 +354,9 @@ buildPythonPackage.override { stdenv = torch.stdenv; } (finalAttrs: {
     ./0003-propagate-pythonpath.patch
     ./0005-drop-intel-reqs.patch
     ./0006-drop-rocm-extra-reqs.patch
+    # QuACK and Cutlass DSL seem to be added only for FA4
+    # which in our case handles its own deps
+    ./0007-drop-quack-reqs.patch
   ];
 
   postPatch = ''
@@ -367,8 +374,7 @@ buildPythonPackage.override { stdenv = torch.stdenv; } (finalAttrs: {
     # pythonRelaxDeps does not cover build-system
     substituteInPlace pyproject.toml \
       --replace-fail "torch ==" "torch >=" \
-      --replace-fail "setuptools>=77.0.3,<81.0.0" "setuptools" \
-      --replace-fail "grpcio-tools==1.78.0" "grpcio"
+      --replace-fail "setuptools>=77.0.3,<81.0.0" "setuptools"
 
     # Ignore the python version check because it hard-codes minor versions and
     # lags behind `ray`'s python interpreter support
@@ -444,6 +450,7 @@ buildPythonPackage.override { stdenv = torch.stdenv; } (finalAttrs: {
 
   dependencies = [
     aioprometheus
+    amd-quark
     anthropic
     bitsandbytes
     blake3
@@ -458,6 +465,7 @@ buildPythonPackage.override { stdenv = torch.stdenv; } (finalAttrs: {
     grpcio-reflection
     ijson
     importlib-metadata
+    kaldi-native-fbank
     llguidance
     lm-format-enforcer
     mcp
@@ -472,6 +480,7 @@ buildPythonPackage.override { stdenv = torch.stdenv; } (finalAttrs: {
     opentelemetry-api
     opentelemetry-exporter-otlp
     opentelemetry-sdk
+    opentelemetry-semantic-conventions-ai
     outlines
     pandas
     partial-json-parser
@@ -510,6 +519,7 @@ buildPythonPackage.override { stdenv = torch.stdenv; } (finalAttrs: {
     nvidia-ml-py
   ]
   ++ lib.optionals rocmSupport [
+    amd-aiter
     rocmPackages.rocminfo
     amdsmi
     datasets
@@ -574,6 +584,11 @@ buildPythonPackage.override { stdenv = torch.stdenv; } (finalAttrs: {
   pythonRelaxDeps = true;
 
   pythonImportsCheck = [ "vllm" ];
+  makeWrapperArgs = lib.optionals cudaSupport [
+    "--set"
+    "VLLM_NCCL_SO_PATH"
+    "${cudaPackages.nccl}/lib/libnccl.so"
+  ];
 
   passthru = {
     # make internal dependency available to overlays

--- a/pkgs/development/python-modules/vllm/default.nix
+++ b/pkgs/development/python-modules/vllm/default.nix
@@ -27,6 +27,7 @@
 
   # dependencies
   aioprometheus,
+  amd-quark,
   amdsmi,
   anthropic,
   bitsandbytes,
@@ -43,6 +44,7 @@
   grpcio-reflection,
   ijson,
   importlib-metadata,
+  kaldi-native-fbank,
   llguidance,
   lm-format-enforcer,
   mcp,
@@ -57,6 +59,7 @@
   opentelemetry-api,
   opentelemetry-exporter-otlp,
   opentelemetry-sdk,
+  opentelemetry-semantic-conventions-ai,
   outlines,
   pandas,
   partial-json-parser,
@@ -335,14 +338,14 @@ in
 
 buildPythonPackage.override { stdenv = torch.stdenv; } (finalAttrs: {
   pname = "vllm";
-  version = "0.16.0";
+  version = "0.19.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "vllm-project";
     repo = "vllm";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-7E67xVRlKmm+Hbp5nphhwH8SQC9LpCFNBfF2ZAOt79k=";
+    hash = "sha256-0gM52DDfLzkE4QXCGR3c3Jq4CQ1PrnDj4Ky0lsUJ2a8=";
   };
 
   patches = [
@@ -367,8 +370,7 @@ buildPythonPackage.override { stdenv = torch.stdenv; } (finalAttrs: {
     # pythonRelaxDeps does not cover build-system
     substituteInPlace pyproject.toml \
       --replace-fail "torch ==" "torch >=" \
-      --replace-fail "setuptools>=77.0.3,<81.0.0" "setuptools" \
-      --replace-fail "grpcio-tools==1.78.0" "grpcio"
+      --replace-fail "setuptools>=77.0.3,<81.0.0" "setuptools"
 
     # Ignore the python version check because it hard-codes minor versions and
     # lags behind `ray`'s python interpreter support
@@ -444,6 +446,7 @@ buildPythonPackage.override { stdenv = torch.stdenv; } (finalAttrs: {
 
   dependencies = [
     aioprometheus
+    amd-quark
     anthropic
     bitsandbytes
     blake3
@@ -458,6 +461,7 @@ buildPythonPackage.override { stdenv = torch.stdenv; } (finalAttrs: {
     grpcio-reflection
     ijson
     importlib-metadata
+    kaldi-native-fbank
     llguidance
     lm-format-enforcer
     mcp
@@ -472,6 +476,7 @@ buildPythonPackage.override { stdenv = torch.stdenv; } (finalAttrs: {
     opentelemetry-api
     opentelemetry-exporter-otlp
     opentelemetry-sdk
+    opentelemetry-semantic-conventions-ai
     outlines
     pandas
     partial-json-parser

--- a/pkgs/development/python-modules/vllm/default.nix
+++ b/pkgs/development/python-modules/vllm/default.nix
@@ -177,8 +177,8 @@ let
   triton-kernels = fetchFromGitHub {
     owner = "triton-lang";
     repo = "triton";
-    tag = "v3.5.0";
-    hash = "sha256-F6T0n37Lbs+B7UHNYzoIQHjNNv3TcMtoXjNrT8ZUlxY=";
+    tag = "v3.6.0";
+    hash = "sha256-JFSpQn+WsNnh7CAPlcpOcUp0nyKXNbJEANdXqmkt4Tc=";
   };
 
   # grep for GIT_TAG in the following file
@@ -353,6 +353,9 @@ buildPythonPackage.override { stdenv = torch.stdenv; } (finalAttrs: {
     ./0003-propagate-pythonpath.patch
     ./0005-drop-intel-reqs.patch
     ./0006-drop-rocm-extra-reqs.patch
+    # QuACK and Cutlass DSL seem to be added only for FA4
+    # which in our case handles its own deps
+    ./0007-drop-quack-reqs.patch
   ];
 
   postPatch = ''
@@ -579,6 +582,11 @@ buildPythonPackage.override { stdenv = torch.stdenv; } (finalAttrs: {
   pythonRelaxDeps = true;
 
   pythonImportsCheck = [ "vllm" ];
+  makeWrapperArgs = lib.optionals cudaSupport [
+    "--set"
+    "VLLM_NCCL_SO_PATH"
+    "${cudaPackages.nccl}/lib/libnccl.so"
+  ];
 
   passthru = {
     # make internal dependency available to overlays

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -11748,6 +11748,10 @@ self: super: with self; {
     callPackage ../development/python-modules/opentelemetry-semantic-conventions
       { };
 
+  opentelemetry-semantic-conventions-ai =
+    callPackage ../development/python-modules/opentelemetry-semantic-conventions-ai
+      { };
+
   opentelemetry-test-utils = callPackage ../development/python-modules/opentelemetry-test-utils { };
 
   opentelemetry-util-http = callPackage ../development/python-modules/opentelemetry-util-http { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -714,6 +714,8 @@ self: super: with self; {
 
   amcrest = callPackage ../development/python-modules/amcrest { };
 
+  amd-aiter = callPackage ../development/python-modules/amd-aiter { };
+
   amd-quark = callPackage ../development/python-modules/amd-quark { };
 
   amdsmi = toPythonModule (

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -11750,6 +11750,10 @@ self: super: with self; {
     callPackage ../development/python-modules/opentelemetry-semantic-conventions
       { };
 
+  opentelemetry-semantic-conventions-ai =
+    callPackage ../development/python-modules/opentelemetry-semantic-conventions-ai
+      { };
+
   opentelemetry-test-utils = callPackage ../development/python-modules/opentelemetry-test-utils { };
 
   opentelemetry-util-http = callPackage ../development/python-modules/opentelemetry-util-http { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8179,6 +8179,8 @@ self: super: with self; {
 
   kaldi-active-grammar = callPackage ../development/python-modules/kaldi-active-grammar { };
 
+  kaldi-native-fbank = callPackage ../development/python-modules/kaldi-native-fbank { };
+
   kaleido = callPackage ../development/python-modules/kaleido { };
 
   kalshi-python = callPackage ../development/python-modules/kalshi-python { };
@@ -11748,6 +11750,10 @@ self: super: with self; {
 
   opentelemetry-semantic-conventions =
     callPackage ../development/python-modules/opentelemetry-semantic-conventions
+      { };
+
+  opentelemetry-semantic-conventions-ai =
+    callPackage ../development/python-modules/opentelemetry-semantic-conventions-ai
       { };
 
   opentelemetry-test-utils = callPackage ../development/python-modules/opentelemetry-test-utils { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8177,6 +8177,8 @@ self: super: with self; {
 
   kaldi-active-grammar = callPackage ../development/python-modules/kaldi-active-grammar { };
 
+  kaldi-native-fbank = callPackage ../development/python-modules/kaldi-native-fbank { };
+
   kaleido = callPackage ../development/python-modules/kaleido { };
 
   kalshi-python = callPackage ../development/python-modules/kalshi-python { };


### PR DESCRIPTION
From what I can tell nvidia-cudnn-frontend, was just added to pin transitive dependnecies of flashinfer which doesn't affect us in nixpkgs right now.

Cubins was added to get some AOT compiled kernels, primarily for blackwell. JIT should still work fine and we can with time update the flashinfer package as well.

See:

- https://github.com/vllm-project/vllm/pull/36719
- https://github.com/vllm-project/vllm/pull/37233
